### PR TITLE
Implementação do LED branco via comando 'white'

### DIFF
--- a/Controle_Pinos2.c
+++ b/Controle_Pinos2.c
@@ -24,6 +24,12 @@ void desligar_leds()
     gpio_put(GPIO_LED_GREEN, false);
     gpio_put(GPIO_LED_BLUE, false);
 }
+void ligar_led_branco() {
+    gpio_put(GPIO_LED_RED, true);
+    gpio_put(GPIO_LED_GREEN, true);
+    gpio_put(GPIO_LED_BLUE, true);
+}
+
 
 int main()
 {
@@ -63,13 +69,17 @@ int main()
                 // Final do comando recebido
                 rx_buffer[buffer_index] = '\0'; // Termina a string
                 buffer_index = 0;               // Reinicia o índice do buffer
+                
 
                 // Verifica o comando recebido
                 if (strcmp(rx_buffer, "off") == 0)
                 {
                     desligar_leds();
                     uart_puts(UART_ID, "Comando recebido: OFF\n");
-                }
+                }else if (strcmp(rx_buffer, "white") == 0) {
+                    ligar_led_branco();
+                    uart_puts(UART_ID, "comando recebido: WHITE\n");
+                } 
             }
             else
             {


### PR DESCRIPTION
Descrição
Adicionada a funcionalidade para ligar o LED branco ao receber o comando "white" via UART. A implementação inclui:

Função ligar_led_branco:

Ativa simultaneamente os LEDs vermelho, verde e azul para criar a cor branca.
Utiliza os pinos GPIO 11 (verde), 12 (azul) e 13 (vermelho).